### PR TITLE
update build file to work in 0.13.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,12 +5,12 @@ pub fn build(b: *Build) void {
     const optimize = b.standardOptimizeOption(.{});
 
     _ = b.addModule("wcwidth", .{
-        .root_source_file = .{ .path = "src/main.zig" },
+        .root_source_file = b.path("src/main.zig"),
     });
 
     const generate = b.addExecutable(.{
         .name = "generate",
-        .root_source_file = .{ .path = "tools/generate.zig" },
+        .root_source_file = b.path("tools/generate.zig"),
         .target = target,
         .optimize = optimize,
     });
@@ -21,7 +21,7 @@ pub fn build(b: *Build) void {
     generate_step.dependOn(&generate_run.step);
 
     const main_tests = b.addTest(.{
-        .root_source_file = .{ .path = "src/test.zig" },
+        .root_source_file = b.path("src/test.zig"),
         .target = target,
         .optimize = optimize,
     });


### PR DESCRIPTION
without this change, build fails with:

     no field named 'path' in union 'Build.LazyPath'

after this change, `zig build test` succeeds.

This is part of two PRs, one here and one against the `linenoize` repo I'll open shorrtly.
I'm working on getting `linenoize` running under 0.13.0, for which `wcwidth` is a dependency.

Thank you for your help and the library!